### PR TITLE
feat: implement history storage mode and update localization

### DIFF
--- a/Hex/Clients/FileClient.swift
+++ b/Hex/Clients/FileClient.swift
@@ -1,0 +1,65 @@
+import Foundation
+import ComposableArchitecture
+import XCTestDynamicOverlay
+
+/// A client that performs file system operations on background-priority threads
+/// to avoid blocking the main actor/UI.
+struct FileClient: Sendable {
+  /// Returns whether a file or directory exists at the given path.
+  /// Executed on a background-priority detached task.
+  var existsAtPath: @Sendable (_ path: String) async -> Bool
+
+  /// Removes the item at the given URL if it exists.
+  /// Executed on a background-priority detached task.
+  var removeItem: @Sendable (_ url: URL) async throws -> Void
+}
+
+extension FileClient {
+  /// Live implementation backed by FileManager, performed on background-priority tasks.
+  static let live = Self(
+    existsAtPath: { path in
+      await Task.detached(priority: .background) {
+        FileManager.default.fileExists(atPath: path)
+      }.value
+    },
+    removeItem: { url in
+      try await Task.detached(priority: .background) {
+        try FileManager.default.removeItem(at: url)
+      }.value
+    }
+  )
+}
+
+extension FileClient: DependencyKey {
+  static var liveValue: FileClient { .live }
+}
+
+extension FileClient: TestDependencyKey {
+  /// The preview implementation does nothing and reports no files present.
+  static var previewValue: FileClient {
+    Self(
+      existsAtPath: { _ in false },
+      removeItem: { _ in }
+    )
+  }
+
+  /// The test implementation is unimplemented by default; override in tests as needed.
+  static var testValue: FileClient {
+    Self(
+      existsAtPath: { _ in
+        XCTFail("Unimplemented: FileClient.existsAtPath")
+        return false
+      },
+      removeItem: { _ in
+        XCTFail("Unimplemented: FileClient.removeItem")
+      }
+    )
+  }
+}
+
+extension DependencyValues {
+  var fileClient: FileClient {
+    get { self[FileClient.self] }
+    set { self[FileClient.self] = newValue }
+  }
+}

--- a/Hex/Clients/FileClient.swift
+++ b/Hex/Clients/FileClient.swift
@@ -12,6 +12,14 @@ struct FileClient: Sendable {
   /// Removes the item at the given URL if it exists.
   /// Executed on a background-priority detached task.
   var removeItem: @Sendable (_ url: URL) async throws -> Void
+
+  /// Creates a directory at the given URL.
+  /// Executed on a background-priority detached task.
+  var createDirectory: @Sendable (_ at: URL, _ withIntermediateDirectories: Bool) async throws -> Void
+
+  /// Moves an item from one URL to another.
+  /// Executed on a background-priority detached task.
+  var moveItem: @Sendable (_ from: URL, _ to: URL) async throws -> Void
 }
 
 extension FileClient {
@@ -26,6 +34,20 @@ extension FileClient {
       try await Task.detached(priority: .background) {
         try FileManager.default.removeItem(at: url)
       }.value
+    },
+    createDirectory: { url, withIntermediateDirectories in
+      try await Task.detached(priority: .background) {
+        try FileManager.default.createDirectory(
+          at: url,
+          withIntermediateDirectories: withIntermediateDirectories,
+          attributes: nil
+        )
+      }.value
+    },
+    moveItem: { from, to in
+      try await Task.detached(priority: .background) {
+        try FileManager.default.moveItem(at: from, to: to)
+      }.value
     }
   )
 }
@@ -39,7 +61,9 @@ extension FileClient: TestDependencyKey {
   static var previewValue: FileClient {
     Self(
       existsAtPath: { _ in false },
-      removeItem: { _ in }
+      removeItem: { _ in },
+      createDirectory: { _, _ in },
+      moveItem: { _, _ in }
     )
   }
 
@@ -52,6 +76,12 @@ extension FileClient: TestDependencyKey {
       },
       removeItem: { _ in
         XCTFail("Unimplemented: FileClient.removeItem")
+      },
+      createDirectory: { _, _ in
+        XCTFail("Unimplemented: FileClient.createDirectory")
+      },
+      moveItem: { _, _ in
+        XCTFail("Unimplemented: FileClient.moveItem")
       }
     )
   }

--- a/Hex/Clients/HistoryStorageClient.swift
+++ b/Hex/Clients/HistoryStorageClient.swift
@@ -1,0 +1,61 @@
+import Foundation
+import ComposableArchitecture
+import XCTestDynamicOverlay
+
+/// A client that centralizes persistence of cleared history and deletion of associated audio files.
+struct HistoryStorageClient: Sendable {
+  /// Persists the cleared history, then deletes all audio files associated with the provided transcripts.
+  /// - Parameters:
+  ///   - sharedHistory: The shared TranscriptionHistory storage to persist after clearing its contents.
+  ///   - transcripts: The transcripts whose audio files should be deleted (if any).
+  var persistClearedHistoryAndDeleteFiles: @Sendable (_ sharedHistory: Shared<TranscriptionHistory>, _ transcripts: [Transcript]) async -> Void
+}
+
+extension HistoryStorageClient: DependencyKey {
+  static var liveValue: HistoryStorageClient {
+    Self(
+      persistClearedHistoryAndDeleteFiles: { sharedHistory, transcripts in
+        // Persist the cleared history first.
+        try? await sharedHistory.save()
+
+        // Delete associated audio files on background threads via FileClient.
+        @Dependency(\.fileClient) var fileClient
+        let urls = transcripts.compactMap(\.audioPath)
+        await withTaskGroup(of: Void.self) { group in
+          for url in urls {
+            group.addTask {
+              try? await fileClient.removeItem(url)
+            }
+          }
+          await group.waitForAll()
+        }
+      }
+    )
+  }
+}
+
+extension HistoryStorageClient: TestDependencyKey {
+  static var previewValue: HistoryStorageClient {
+    Self(
+      persistClearedHistoryAndDeleteFiles: { sharedHistory, _ in
+        // Preview: persist only, do not delete files
+        try? await sharedHistory.save()
+      }
+    )
+  }
+
+  static var testValue: HistoryStorageClient {
+    Self(
+      persistClearedHistoryAndDeleteFiles: { _, _ in
+        XCTFail("Unimplemented: HistoryStorageClient.persistClearedHistoryAndDeleteFiles")
+      }
+    )
+  }
+}
+
+extension DependencyValues {
+  var historyStorage: HistoryStorageClient {
+    get { self[HistoryStorageClient.self] }
+    set { self[HistoryStorageClient.self] = newValue }
+  }
+}

--- a/Hex/Clients/HistoryStorageClient.swift
+++ b/Hex/Clients/HistoryStorageClient.swift
@@ -22,11 +22,7 @@ extension HistoryStorageClient: DependencyKey {
     Self(
       persistClearedHistoryAndDeleteFiles: { sharedHistory, transcripts in
         // Save first; if this throws, do not delete any files.
-        do {
-          try await sharedHistory.save()
-        } catch {
-          throw error
-        }
+        try await sharedHistory.save()
 
         // Delete associated audio files on background threads via FileClient.
         @Dependency(\.fileClient) var fileClient
@@ -46,11 +42,7 @@ extension HistoryStorageClient: DependencyKey {
       },
       persistHistoryAndDeleteFiles: { sharedHistory, files in
         // Save first; if this throws, do not delete any files.
-        do {
-          try await sharedHistory.save()
-        } catch {
-          throw error
-        }
+        try await sharedHistory.save()
 
         // Delete provided files after a successful save.
         @Dependency(\.fileClient) var fileClient

--- a/Hex/Features/History/HistoryFeature.swift
+++ b/Hex/Features/History/HistoryFeature.swift
@@ -280,10 +280,14 @@ struct HistoryFeature {
 				}
 
 				// Persist history, then delete the audio file (if any) via HistoryStorageClient
-				return .run { [sharedHistory = state.$transcriptionHistory, transcript] _ in
-					let files = transcript.audioPath.map { [$0] } ?? []
-					try? await historyStorage.persistHistoryAndDeleteFiles(sharedHistory, files)
-				}
+                return .run { [sharedHistory = state.$transcriptionHistory, transcript] _ in
+                    do {
+                        let files = transcript.audioPath.map { [$0] } ?? []
+                        try await historyStorage.persistHistoryAndDeleteFiles(sharedHistory, files)
+                    } catch {
+                        print("Failed to persist transcript deletion: \(error.localizedDescription)")
+                    }
+                }
 
 			case .deleteAllTranscripts:
 				return .send(.confirmDeleteAll)

--- a/Hex/Features/History/HistoryFeature.swift
+++ b/Hex/Features/History/HistoryFeature.swift
@@ -15,10 +15,7 @@ struct Transcript: Codable, Equatable, Identifiable {
 
 	// Computed property indicating whether an audio file exists for this transcript
 	var hasAudio: Bool {
-		if let url = audioPath {
-			return FileManager.default.fileExists(atPath: url.path)
-		}
-		return false
+		audioPath.map { FileManager.default.fileExists(atPath: $0.path) } ?? false
 	}
 
 	init(id: UUID = UUID(), timestamp: Date, text: String, audioPath: URL?, duration: TimeInterval) {
@@ -124,7 +121,7 @@ struct HistoryFeature {
 					return .none
 				}
 				// Ensure audio exists
-				guard let url = transcript.audioPath, FileManager.default.fileExists(atPath: url.path) else {
+				guard transcript.hasAudio, let url = transcript.audioPath else {
 					return .none
 				}
 

--- a/Hex/Features/History/HistoryFeature.swift
+++ b/Hex/Features/History/HistoryFeature.swift
@@ -238,12 +238,12 @@ struct HistoryFeature {
 					}
 				} catch {
 					print("Error playing audio: \(error)")
-		// Surface error to user via alert
-		return .run { _ in
-			await MainActor.run {
-			_ = NSApp.presentError(error as NSError)
-			}
-		}
+				// Surface error to user via alert
+				return .run { _ in
+					await MainActor.run {
+						_ = NSApp.presentError(error as NSError)
+					}
+				}
 				}
 
 			case .stopPlayback, .playbackFinished:

--- a/Hex/Features/History/HistoryFeature.swift
+++ b/Hex/Features/History/HistoryFeature.swift
@@ -307,9 +307,13 @@ struct HistoryFeature {
 				}
 
 				// Delete files after ensuring state persistence completes
-				return .run { [sharedHistory = state.$transcriptionHistory, transcripts] _ in
-					try? await historyStorage.persistClearedHistoryAndDeleteFiles(sharedHistory, transcripts)
-				}
+                return .run { [sharedHistory = state.$transcriptionHistory, transcripts] _ in
+                    do {
+                        try await historyStorage.persistClearedHistoryAndDeleteFiles(sharedHistory, transcripts)
+                    } catch {
+                        print("Failed to persist deletion of all transcripts: \(error.localizedDescription)")
+                    }
+                }
 
 			case .navigateToSettings:
 				// This will be handled by the parent reducer

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -266,11 +266,8 @@ struct SettingsFeature {
           return .run { [sharedHistory = state.$transcriptionHistory] _ in
             // Explicitly save the state and wait for completion before deleting files
             try? await sharedHistory.save()
-            for transcript in transcripts {
-              if let url = transcript.audioPath {
-                try? FileManager.default.removeItem(at: url)
-              }
-            }
+            let fm = FileManager.default
+            transcripts.compactMap(\.audioPath).forEach { try? fm.removeItem(at: $0) }
           }
         }
 

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -262,8 +262,10 @@ struct SettingsFeature {
             history.history.removeAll()
           }
 
-          // Delete all audio files associated with existing transcripts
-          return .run { _ in
+          // Persist cleared history, then delete all audio files associated with existing transcripts
+          return .run { [sharedHistory = state.$transcriptionHistory] _ in
+            // Explicitly save the state and wait for completion before deleting files
+            try? await sharedHistory.save()
             for transcript in transcripts {
               if let url = transcript.audioPath {
                 try? FileManager.default.removeItem(at: url)

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -265,7 +265,7 @@ struct SettingsFeature {
 
           // Persist cleared history, then delete all audio files associated with existing transcripts
           return .run { [sharedHistory = state.$transcriptionHistory, transcripts] _ in
-            await historyStorage.persistClearedHistoryAndDeleteFiles(sharedHistory, transcripts)
+            try? await historyStorage.persistClearedHistoryAndDeleteFiles(sharedHistory, transcripts)
           }
         }
 

--- a/Hex/Features/Settings/SettingsView.swift
+++ b/Hex/Features/Settings/SettingsView.swift
@@ -251,18 +251,23 @@ struct SettingsView: View {
 			// --- History Section ---
 			Section {
 				Label {
-					Toggle("Save Transcription History", isOn: Binding(
-						get: { store.hexSettings.saveTranscriptionHistory },
-						set: { store.send(.toggleSaveTranscriptionHistory($0)) }
-					))
-					Text("Save transcriptions and audio recordings for later access")
-						.font(.caption)
-						.foregroundColor(.secondary)
+					Picker(
+						"History Storage",
+						selection: Binding(
+							get: { store.hexSettings.historyStorageMode },
+							set: { store.send(.setHistoryStorageMode($0)) }
+						)
+					) {
+						Text("Off").tag(HexSettings.HistoryStorageMode.off)
+						Text("Text only").tag(HexSettings.HistoryStorageMode.textOnly)
+						Text("Text + Audio").tag(HexSettings.HistoryStorageMode.textAndAudio)
+					}
+					.pickerStyle(.segmented)
 				} icon: {
 					Image(systemName: "clock.arrow.circlepath")
 				}
 
-				if store.hexSettings.saveTranscriptionHistory {
+				if store.hexSettings.historyStorageMode != .off {
 					Label {
 						HStack {
 							Text("Maximum History Entries")
@@ -297,8 +302,17 @@ struct SettingsView: View {
 			} header: {
 				Text("History")
 			} footer: {
-				if !store.hexSettings.saveTranscriptionHistory {
-					Text("When disabled, transcriptions will not be saved and audio files will be deleted immediately after transcription.")
+				switch store.hexSettings.historyStorageMode {
+				case .off:
+					Text("Transcriptions are not saved. Audio files are deleted immediately after transcription.")
+						.font(.footnote)
+						.foregroundColor(.secondary)
+				case .textOnly:
+					Text("Only transcript text and metadata are saved. Audio recordings are discarded after transcription.")
+						.font(.footnote)
+						.foregroundColor(.secondary)
+				case .textAndAudio:
+					Text("Transcripts and audio recordings are saved for later access.")
 						.font(.footnote)
 						.foregroundColor(.secondary)
 				}

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -474,7 +474,7 @@ private extension TranscriptionFeature {
             maxEntries: hexSettings.maxHistoryEntries
           )
           // Persist history first, then delete any trimmed files. Persist even if nothing to delete.
-          try? await historyStorage.persistHistoryAndDeleteFiles(transcriptionHistory, filesToDelete)
+          try await historyStorage.persistHistoryAndDeleteFiles(transcriptionHistory, filesToDelete)
         }
 
         // Paste text (and copy if enabled via pasteWithClipboard)

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -444,12 +444,7 @@ private extension TranscriptionFeature {
         // First, determine the final audio path based on storage mode
         let finalAudioURL: URL?
         switch hexSettings.historyStorageMode {
-        case .off:
-          // Do not save transcript; just delete the temporary audio file.
-          try? fm.removeItem(at: originalURL)
-          finalAudioURL = nil
-
-        case .textOnly:
+        case .off, .textOnly:
           // Delete the temporary audio file; no audio is stored.
           try? fm.removeItem(at: originalURL)
           finalAudioURL = nil

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -310,6 +310,9 @@
     "History Disabled" : {
 
     },
+    "History Storage" : {
+
+    },
     "Hot Key" : {
       "comment" : "hotkey section in settings.",
       "localizations" : {
@@ -380,7 +383,13 @@
         }
       }
     },
+    "Off" : {
+
+    },
     "Oldest entries will be automatically deleted when limit is reached" : {
+
+    },
+    "Only transcript text and metadata are saved. Audio recordings are discarded after transcription." : {
 
     },
     "Open on Login" : {
@@ -476,12 +485,6 @@
       }
     },
     "RNNT" : {
-
-    },
-    "Save Transcription History" : {
-
-    },
-    "Save transcriptions and audio recordings for later access" : {
 
     },
     "Selected device not connected. System default will be used." : {
@@ -604,6 +607,12 @@
     "System Default" : {
 
     },
+    "Text + Audio" : {
+
+    },
+    "Text only" : {
+
+    },
     "Transcription history is currently disabled." : {
 
     },
@@ -617,6 +626,12 @@
           }
         }
       }
+    },
+    "Transcriptions are not saved. Audio files are deleted immediately after transcription." : {
+
+    },
+    "Transcripts and audio recordings are saved for later access." : {
+
     },
     "Unlimited" : {
 
@@ -667,9 +682,6 @@
           }
         }
       }
-    },
-    "When disabled, transcriptions will not be saved and audio files will be deleted immediately after transcription." : {
-
     },
     "You're using a full keyboard shortcut. Double-tap is recommended." : {
 


### PR DESCRIPTION
- Introduced a new `HistoryStorageMode` enum in `HexSettings` to manage how transcription history is stored (off, text only, text + audio).
- Updated `SettingsView` to allow users to select their preferred history storage mode via a segmented picker.
- Refactored `TranscriptionFeature` to handle audio file management based on the selected storage mode.
- Enhanced `HistoryFeature` to clear history and delete audio files when history is disabled.
- Added new localization entries in `Localizable.xcstrings` for updated history management options.

#16 